### PR TITLE
(fix) locale number fr-CH

### DIFF
--- a/main/fr-CH/numbers.json
+++ b/main/fr-CH/numbers.json
@@ -16,8 +16,8 @@
         },
         "minimumGroupingDigits": "1",
         "symbols-numberSystem-latn": {
-          "decimal": ",",
-          "group": " ",
+          "decimal": ".",
+          "group": "'",
           "list": ";",
           "percentSign": "%",
           "plusSign": "+",


### PR DESCRIPTION
group separator for thousands is a quote and for decimal a dot. For example one thousand and fifty cents : 1'000.15 and not 1 000,15