### PR TITLE
group sperator update

### DIFF
--- a/main/fr-BE/numbers.json
+++ b/main/fr-BE/numbers.json
@@ -16,7 +16,7 @@
         "minimumGroupingDigits": "1",
         "symbols-numberSystem-latn": {
           "decimal": ",",
-          "group": " ",
+          "group": ".",
           "list": ";",
           "percentSign": "%",
           "plusSign": "+",


### PR DESCRIPTION
The separtor between groups in belgium is "." not " "